### PR TITLE
fix: get dedicated worker file name for ipc

### DIFF
--- a/src/main/node/self.js
+++ b/src/main/node/self.js
@@ -5,8 +5,13 @@ const ipc = require('./ipc.js');
 // open socket
 let d_socket = new net.Socket({fd:4});
 
+// returns root module
+function getRootModule(module){
+	return module.parent ? getRootModule(module.parent) : module;
+}
+
 // create ipc
 module.exports = new ipc(d_socket, {
-	origin: module.parent.parent.parent.filename,
+	origin: getRootModule(module).filename,
 	args: process.argv.slice(2),
 });


### PR DESCRIPTION
dedicated  worker fails if bundled with webpack (module.parent == null).